### PR TITLE
build-docs hotfix

### DIFF
--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -25,5 +25,5 @@ jobs:
           path: .cache
           restore-keys: |
             mkdocs-material-
-      - run: pip install mkdocs-material
+      - run: pip install mkdocs-material mkdocstrings[python]
       - run: mkdocs gh-deploy --force


### PR DESCRIPTION
Add mkdocstrings[python] to build-docs.yml