### PR TITLE
fix: Pagination and Sorting models does not require a .dict call

### DIFF
--- a/outline_wiki_api/resources/documents.py
+++ b/outline_wiki_api/resources/documents.py
@@ -141,9 +141,9 @@ class Documents(Resources):
         if template is not None:
             data["template"] = template
         if pagination:
-            data.update(pagination.dict())
+            data.update(pagination)
         if sorting:
-            data.update(sorting.dict())
+            data.update(sorting)
 
         response = self.post("list", data=data)
         return DocumentListResponse(**response.json())
@@ -264,10 +264,7 @@ class Documents(Resources):
         if date_filter:
             data["dateFilter"] = date_filter
         if pagination:
-            if isinstance(pagination, Pagination):
-                data.update(pagination.dict())
-            elif isinstance(pagination, Dict):
-                data.update(pagination)
+            data.update(pagination)
 
         response = self.post("search", data=data)
 


### PR DESCRIPTION
👋 Hello

In the same way as the documents.create(), support both Pagination objects and dictionaries.

Thanks