### PR TITLE
feat: add info(), update(), delete() and list() methods to Comments class

### DIFF
--- a/outline_wiki_api/models/comment.py
+++ b/outline_wiki_api/models/comment.py
@@ -1,0 +1,96 @@
+from datetime import datetime
+from typing import Optional, List
+from pydantic import BaseModel, Field
+from uuid import UUID
+from .user import User
+from .response import Response
+
+
+class Data(BaseModel):
+    """
+    Represents the data structure of a comment's content.
+    """
+
+    type: str = Field(
+        ..., description="The type of the document node", examples=["doc"]
+    )
+    content: List[dict] = Field(
+        ...,
+        description="The content of the document node",
+    )
+
+
+class Comment(BaseModel):
+    """
+    Represents a comment in the system.
+    """
+
+    id: UUID = Field(
+        ...,
+        json_schema_extra={
+            "description": "Unique identifier for the object",
+            "example": "550e8400-e29b-41d4-a716-446655440000",
+            "read_only": "true",
+        },
+    )
+    parent_comment_id: Optional[UUID] = Field(
+        None,
+        alias="parentCommentId",
+        description="Identifier for the comment this is a child of, if any.",
+        examples=["550e8400-e29b-41d4-a716-446655440001"],
+    )
+    data: Data = Field(
+        ...,
+        alias="data",
+        description="The editor data representing this comment.",
+    )
+    document_id: UUID = Field(
+        ...,
+        alias="documentId",
+        description="Identifier for the document this is related to.",
+        examples=["550e8400-e29b-41d4-a716-446655440002"],
+    )
+    created_at: datetime = Field(
+        ...,
+        alias="createdAt",
+        description="The date and time that this object was created",
+        examples=["2023-01-15T09:30:00Z"],
+        json_schema_extra={"read_only": "true"},
+    )
+    created_by: User = Field(
+        ...,
+        alias="createdBy",
+        description="User who created this comment",
+        json_schema_extra={"read_only": "true"},
+    )
+    updated_at: Optional[datetime] = Field(
+        ...,
+        alias="updatedAt",
+        description="The date and time that this object was last changed",
+        examples=["2023-06-20T14:25:00Z"],
+        json_schema_extra={"read_only": "true"},
+    )
+    updated_by: Optional[User] = Field(
+        None,
+        alias="updatedBy",
+        description="User who last updated this comment",
+        json_schema_extra={"read_only": "true"},
+    )
+    anchor_text: Optional[str] = Field(
+        None,
+        alias="anchorText",
+        description="The document text that the comment is anchored to, only included if includeAnchorText=true.",
+        json_schema_extra={"read_only": "true"},
+    )
+
+
+class CommentResponse(Response):
+    """A single Comment object response"""
+
+    data: Optional[Comment] = None
+
+
+class CommentListResponse(Response):
+    """A Collection of the Comment objects response"""
+
+    data: Optional[List[Comment]] = None

--- a/outline_wiki_api/resources/comments.py
+++ b/outline_wiki_api/resources/comments.py
@@ -1,5 +1,7 @@
 from uuid import UUID
 from .base import Resources
+from ..models.response import Pagination, Sort
+from ..models.comment import CommentResponse, CommentListResponse, Data
 
 
 class Comments(Resources):
@@ -49,4 +51,92 @@ class Comments(Resources):
             payload["text"] = text
 
         response = self.post("create", data=payload)
-        return response.json()
+        return CommentResponse(**response.json())
+
+    def info(self, comment_id: UUID | str) -> CommentResponse:
+        """
+        Retrieve a single comment by its ID.
+
+        Args:
+            comment_id: The ID of the comment to retrieve
+
+        Returns:
+            The requested comment
+        """
+        response = self.post("info", data={"id": str(comment_id)})
+        return CommentResponse(**response.json())
+
+    def update(
+        self,
+        comment_id: UUID | str,
+        data: Data | None = None,
+    ) -> CommentResponse:
+        """
+        Update an existing comment.
+
+        Args:
+            comment_id: The ID of the comment to update
+            data: The updated body of the comment
+
+        Returns:
+            The updated comment
+        """
+        payload = {"id": str(comment_id)}
+        if data:
+            payload["data"] = data
+
+        response = self.post("update", data=payload)
+        return CommentResponse(**response.json())
+
+    def delete(self, comment_id: UUID | str) -> CommentResponse:
+        """
+        Delete a comment by its ID.
+
+        Args:
+            comment_id: The ID of the comment to delete
+
+        Returns:
+            The deleted comment
+        """
+        response = self.post("delete", data={"id": str(comment_id)})
+        return CommentResponse(**response.json())
+
+    def list(
+        self,
+        collection_id: UUID | str | None = None,
+        document_id: UUID | str | None = None,
+        direction: str | None = None,
+        include_anchor_text: bool | None = None,
+        pagination: Pagination | None = None,
+        sorting: Sort | None = None,
+    ) -> CommentListResponse:
+        """
+        List all comments, with optional filters for collection or document.
+
+        Args:
+            collection_id: The ID of the collection to filter comments by
+            document_id: The ID of the document to filter comments by
+            direction: The direction of the comments to filter by (e.g., "inbound", "outbound")
+            include_anchor_text: Whether to include anchor text in the response
+            pagination: Pagination settings
+            sorting: Sorting settings
+
+        Returns:
+            A list of comments matching the filters
+        """
+        data = {}
+        if collection_id:
+            data["collectionId"] = str(collection_id)
+        if document_id:
+            data["documentId"] = str(document_id)
+        if direction:
+            data["direction"] = direction
+        if include_anchor_text is not None:
+            data["includeAnchorText"] = include_anchor_text
+        if pagination:
+            data.update(pagination)
+        if sorting:
+            data.update(sorting)
+
+        response = self.post("list", data=data)
+        return CommentListResponse(**response.json())


### PR DESCRIPTION
This commit adds the following methods to the Comments class:

- info
- update
- delete
- list

These methods expand the functionality of the Comments resource, allowing for retrieving, updating, deleting, and listing comments.

I'm not so familiar with Pydantic, it's very likely there are some flaws... feel free to comment or update 🙏 